### PR TITLE
Fix cipher initialization

### DIFF
--- a/lib/secure_yaml/cipher.rb
+++ b/lib/secure_yaml/cipher.rb
@@ -7,22 +7,20 @@ module SecureYaml
   class Cipher
 
     def encrypt(secret_key, plain_data)
-      cipher = create_cipher(secret_key)
-      cipher.encrypt
+      cipher = create_cipher(secret_key, :encrypt)
       strip_newline_chars_from_base64(Base64.encode64(cipher.update(plain_data) + cipher.final))
     end
 
     def decrypt(secret_key, encrypted_data)
-      cipher = create_cipher(secret_key)
-      cipher.decrypt
+      cipher = create_cipher(secret_key, :decrypt)
       cipher.update(Base64.decode64(encrypted_data)) + cipher.final
     end
     
     private
 
-    def create_cipher(secret_key)
+    def create_cipher(secret_key, method)
       cipher = OpenSSL::Cipher.new("AES-256-CFB")
-      cipher.encrypt
+      cipher.__send__(method)
       cipher.key = Digest::SHA2.new(256).digest(secret_key)
       cipher
     end


### PR DESCRIPTION
According to [OpenSSL documentation](https://ruby.github.io/openssl/OpenSSL/Cipher.html), calling encrypt or decrypt methods on cipher after setting it's key reset the configuration.
This should fix #8 